### PR TITLE
Referencing Polaris config file as part of deployment config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 deploy
+examples
 .gitignore
 .git/*
 Dockerfile

--- a/deploy/dashboard.yaml
+++ b/deploy/dashboard.yaml
@@ -158,6 +158,8 @@ spec:
       - command:
         - polaris
         - --dashboard
+        - --config
+        - /opt/app/config.yaml
         image: 'quay.io/reactiveops/polaris:0.1.1'
         imagePullPolicy: 'Always'
         name: dashboard

--- a/deploy/helm/polaris/templates/dashboard.deployment.yaml
+++ b/deploy/helm/polaris/templates/dashboard.deployment.yaml
@@ -29,6 +29,8 @@ spec:
       - command:
         - polaris
         - --dashboard
+        - --config
+        - /opt/app/config.yaml
         image: '{{.Values.dashboard.image.repository}}:{{.Values.dashboard.image.tag}}'
         imagePullPolicy: '{{.Values.dashboard.image.pullPolicy}}'
         name: dashboard

--- a/deploy/helm/polaris/templates/webhook.deployment.yaml
+++ b/deploy/helm/polaris/templates/webhook.deployment.yaml
@@ -26,6 +26,8 @@ spec:
           command:
             - polaris
             - --webhook
+            - --config
+            - /opt/app/config.yaml
           image: '{{.Values.webhook.image.repository}}:{{.Values.webhook.image.tag}}'
           imagePullPolicy: '{{.Values.webhook.image.pullPolicy}}'
           ports:

--- a/deploy/webhook.yaml
+++ b/deploy/webhook.yaml
@@ -208,6 +208,8 @@ spec:
           command:
             - polaris
             - --webhook
+            - --config
+            - /opt/app/config.yaml
           image: 'quay.io/reactiveops/polaris:0.1.1'
           imagePullPolicy: 'Always'
           ports:


### PR DESCRIPTION
When we embedded the Polaris config into the binary with packr, we failed to update the deployment config to actually point to the Polaris config we were mounting in to the pod with a configmap. That meant that if changed a value in the configmap, it wouldn't actually change the Polaris config being used, this should fix that.