### PR TITLE
Adding exception for init container resource checks

### DIFF
--- a/pkg/validator/container.go
+++ b/pkg/validator/container.go
@@ -55,6 +55,12 @@ func ValidateContainer(cnConf *conf.Configuration, container *corev1.Container, 
 }
 
 func (cv *ContainerValidation) validateResources(resConf *conf.Resources) {
+	// Only validate resources for primary containers. Although it can
+	// be helpful to set these in certain cases, it usually isn't
+	if cv.IsInitContainer {
+		return
+	}
+
 	category := messages.CategoryResources
 	res := cv.Container.Resources
 

--- a/pkg/validator/container_test.go
+++ b/pkg/validator/container_test.go
@@ -161,6 +161,27 @@ func TestValidateResourcesPartiallyValid(t *testing.T) {
 	testValidateResources(t, &container, &resourceConf1, &expectedErrors, &expectedWarnings)
 }
 
+func TestValidateResourcesInit(t *testing.T) {
+	cvEmpty := ContainerValidation{
+		Container:          &corev1.Container{},
+		ResourceValidation: &ResourceValidation{},
+	}
+	cvInit := ContainerValidation{
+		Container:          &corev1.Container{},
+		ResourceValidation: &ResourceValidation{},
+		IsInitContainer:    true,
+	}
+
+	parsedConf, err := conf.Parse([]byte(resourceConf1))
+	assert.NoError(t, err, "Expected no error when parsing config")
+
+	cvEmpty.validateResources(&parsedConf.Resources)
+	assert.Len(t, cvEmpty.Errors, 4)
+
+	cvInit.validateResources(&parsedConf.Resources)
+	assert.Len(t, cvInit.Errors, 0)
+}
+
 func TestValidateResourcesFullyValid(t *testing.T) {
 	cpuRequest, err := resource.ParseQuantity("300m")
 	assert.NoError(t, err, "Error parsing quantity")


### PR DESCRIPTION
Although resource requests and limits can sometimes make sense for init containers, they usually do not. Because of that (originally mentioned by #125), we're going to ignore those checks by default for init containers. In the future it may make sense to allow this validation to be optionally enabled.