### PR TITLE
Show cluster name/host on dashboard

### DIFF
--- a/deploy/helm/polaris/templates/dashboard.deployment.yaml
+++ b/deploy/helm/polaris/templates/dashboard.deployment.yaml
@@ -31,6 +31,10 @@ spec:
         - --dashboard
         - --config
         - /opt/app/config.yaml
+        {{- with .Values.dashboard.clusterName }}
+        - --cluster-name
+        - {{ . }}
+        {{- end }}
         image: '{{.Values.dashboard.image.repository}}:{{.Values.dashboard.image.tag}}'
         imagePullPolicy: '{{.Values.dashboard.image.pullPolicy}}'
         name: dashboard

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func main() {
 	auditOutputURL := flag.String("output-url", "", "Destination URL to send audit results")
 	auditOutputFile := flag.String("output-file", "", "Destination file for audit results")
 	auditOutputFormat := flag.String("output-format", "json", "Output format for results - json, yaml, or score")
+	displayName := flag.String("display-name", "", "An optional identifier for the audit")
 	configPath := flag.String("config", "", "Location of Polaris configuration file")
 	logLevel := flag.String("log-level", logrus.InfoLevel.String(), "Logrus log level")
 	version := flag.Bool("version", false, "Prints the version of Polaris")
@@ -77,6 +78,9 @@ func main() {
 	}
 
 	c, err := conf.ParseFile(*configPath)
+	if *displayName != "" {
+		c.DisplayName = *displayName
+	}
 	if err != nil {
 		logrus.Errorf("Error parsing config at %s: %v", *configPath, err)
 		os.Exit(1)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,7 @@ import (
 
 // Configuration contains all of the config for the validation checks.
 type Configuration struct {
+	DisplayName  string       `json:"displayName"`
 	Resources    Resources    `json:"resources"`
 	HealthChecks HealthChecks `json:"healthChecks"`
 	Images       Images       `json:"images"`

--- a/pkg/dashboard/assets/css/dashboard.css
+++ b/pkg/dashboard/assets/css/dashboard.css
@@ -9,11 +9,14 @@
   font-weight: 300;
   font-size: 28px;
   padding: 20px 20px;
+  white-space: nowrap;
+  overflow: hidden;
+  margin-left: -2px; /* Fix for kerning issue */
 }
 
 .card.cluster h3 {
   padding: 0px;
-  padding-bottom: 10px;
+  padding-bottom: 20px;
 }
 
 .card.namespace h3 strong {
@@ -21,9 +24,7 @@
 }
 
 .cluster-overview {
-  position: relative;
   top: -60px;
-  margin-bottom: -60px;
 }
 
 .cluster-overview .graph {
@@ -38,11 +39,12 @@
   display: inline-block;
   width: 32%;
   vertical-align: top;
-  padding-top: 65px;
 }
-
+.cluster-overview .cluster-score{
+  padding-top: 15px;
+}
 .cluster-overview .result-messages {
-  padding-top: 90px;
+  padding-top: 70px;
 }
 
 .cluster-overview .graph canvas {

--- a/pkg/dashboard/assets/css/dashboard.css
+++ b/pkg/dashboard/assets/css/dashboard.css
@@ -15,8 +15,8 @@
 }
 
 .card.cluster h3 {
-  padding: 0px;
-  padding-bottom: 20px;
+  padding: 4px 0px;
+  margin-bottom: 20px;
 }
 
 .card.namespace h3 strong {

--- a/pkg/dashboard/templates/dashboard.gohtml
+++ b/pkg/dashboard/templates/dashboard.gohtml
@@ -1,6 +1,11 @@
 {{define "dashboard"}}
   <div class="card cluster">
-    <h3>Cluster Overview</h3>
+    <h3>
+      <span>{{ .AuditData.SourceType }} Overview</span>
+{{- if .AuditData.DisplayName -}}
+<small>: {{ .AuditData.DisplayName }}</small>
+{{ end }}
+    </h3>
     <div class="cluster-overview">
       <div class="cluster-score">
         <div class="score-details">

--- a/pkg/kube/resources_test.go
+++ b/pkg/kube/resources_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/reactiveops/polaris/test"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 func TestGetResourcesFromPath(t *testing.T) {
@@ -14,6 +15,7 @@ func TestGetResourcesFromPath(t *testing.T) {
 	assert.Equal(t, "Path", resources.SourceType, "Should have type Path")
 	assert.Equal(t, "./test_files/test_1", resources.SourceName, "Should have filename as name")
 	assert.Equal(t, "unknown", resources.ServerVersion, "Server version should be unknown")
+	assert.IsType(t, time.Now(), resources.CreationTime, "Creation time should be set")
 
 	assert.Equal(t, 0, len(resources.Nodes), "Should not have any nodes")
 
@@ -36,6 +38,7 @@ func TestGetMultipleResourceFromSingleFile(t *testing.T) {
 	assert.Equal(t, "Path", resources.SourceType, "Should have type Path")
 	assert.Equal(t, "./test_files/test_2/multi.yaml", resources.SourceName, "Should have filename as name")
 	assert.Equal(t, "unknown", resources.ServerVersion, "Server version should be unknown")
+	assert.IsType(t, time.Now(), resources.CreationTime, "Creation time should be set")
 
 	assert.Equal(t, 0, len(resources.Nodes), "Should not have any nodes")
 
@@ -55,6 +58,7 @@ func TestGetResourceFromAPI(t *testing.T) {
 
 	assert.Equal(t, "Cluster", resources.SourceType, "Should have type Path")
 	assert.Equal(t, "test", resources.SourceName, "Should have source name")
+	assert.IsType(t, time.Now(), resources.CreationTime, "Creation time should be set")
 
 	assert.Equal(t, 0, len(resources.Nodes), "Should not have any nodes")
 	assert.Equal(t, 1, len(resources.Deployments), "Should have a deployment")

--- a/pkg/kube/resources_test.go
+++ b/pkg/kube/resources_test.go
@@ -11,6 +11,8 @@ func TestGetResourcesFromPath(t *testing.T) {
 
 	assert.Equal(t, nil, err, "Error should be nil")
 
+	assert.Equal(t, "Path", resources.SourceType, "Should have type Path")
+	assert.Equal(t, "./test_files/test_1", resources.SourceName, "Should have filename as name")
 	assert.Equal(t, "unknown", resources.ServerVersion, "Server version should be unknown")
 
 	assert.Equal(t, 0, len(resources.Nodes), "Should not have any nodes")
@@ -31,6 +33,8 @@ func TestGetMultipleResourceFromSingleFile(t *testing.T) {
 
 	assert.Equal(t, nil, err, "Error should be nil")
 
+	assert.Equal(t, "Path", resources.SourceType, "Should have type Path")
+	assert.Equal(t, "./test_files/test_2/multi.yaml", resources.SourceName, "Should have filename as name")
 	assert.Equal(t, "unknown", resources.ServerVersion, "Server version should be unknown")
 
 	assert.Equal(t, 0, len(resources.Nodes), "Should not have any nodes")
@@ -46,8 +50,11 @@ func TestGetMultipleResourceFromSingleFile(t *testing.T) {
 func TestGetResourceFromAPI(t *testing.T) {
 	k8s := test.SetupTestAPI()
 	k8s = test.SetupAddDeploys(k8s, "test")
-	resources, err := CreateResourceProviderFromAPI(k8s)
+	resources, err := CreateResourceProviderFromAPI(k8s, "test")
 	assert.Equal(t, nil, err, "Error should be nil")
+
+	assert.Equal(t, "Cluster", resources.SourceType, "Should have type Path")
+	assert.Equal(t, "test", resources.SourceName, "Should have source name")
 
 	assert.Equal(t, 0, len(resources.Nodes), "Should not have any nodes")
 	assert.Equal(t, 1, len(resources.Deployments), "Should have a deployment")

--- a/pkg/validator/fullaudit.go
+++ b/pkg/validator/fullaudit.go
@@ -1,6 +1,8 @@
 package validator
 
 import (
+	"time"
+
 	conf "github.com/reactiveops/polaris/pkg/config"
 	"github.com/reactiveops/polaris/pkg/kube"
 )
@@ -24,6 +26,10 @@ type ClusterSummary struct {
 // AuditData contains all the data from a full Polaris audit
 type AuditData struct {
 	PolarisOutputVersion string
+	AuditTime            string
+	SourceType           string
+	SourceName           string
+	DisplayName          string
 	ClusterSummary       ClusterSummary
 	NamespacedResults    NamespacedResults
 }
@@ -50,8 +56,17 @@ func RunAudit(config conf.Configuration, kubeResources *kube.ResourceProvider) (
 		}
 	}
 
+	displayName := config.DisplayName
+	if displayName == "" {
+		displayName = kubeResources.SourceName
+	}
+
 	auditData := AuditData{
 		PolarisOutputVersion: PolarisOutputVersion,
+		AuditTime:            kubeResources.CreationTime.Format(time.RFC3339),
+		SourceType:           kubeResources.SourceType,
+		SourceName:           kubeResources.SourceName,
+		DisplayName:          displayName,
 		ClusterSummary: ClusterSummary{
 			Version:     kubeResources.ServerVersion,
 			Nodes:       len(kubeResources.Nodes),

--- a/pkg/validator/fullaudit.go
+++ b/pkg/validator/fullaudit.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// PolarisOutputVersion is the version of the current output structure
-	PolarisOutputVersion = "0.1"
+	PolarisOutputVersion = "0.2"
 )
 
 // ClusterSummary contains Polaris results as well as some high-level stats

--- a/pkg/validator/fullaudit_test.go
+++ b/pkg/validator/fullaudit_test.go
@@ -12,7 +12,7 @@ import (
 func TestGetTemplateData(t *testing.T) {
 	k8s := test.SetupTestAPI()
 	k8s = test.SetupAddDeploys(k8s, "test")
-	resources, err := kube.CreateResourceProviderFromAPI(k8s)
+	resources, err := kube.CreateResourceProviderFromAPI(k8s, "test")
 	assert.Equal(t, err, nil, "error should be nil")
 
 	c := conf.Configuration{
@@ -45,6 +45,8 @@ func TestGetTemplateData(t *testing.T) {
 	assert.Equal(t, err, nil, "error should be nil")
 
 	assert.EqualValues(t, sum, actualAudit.ClusterSummary.Results)
+	assert.Equal(t, actualAudit.SourceType, "Cluster", "should be from a cluster")
+	assert.Equal(t, actualAudit.SourceName, "test", "should be from a cluster")
 	assert.Equal(t, 1, len(actualAudit.NamespacedResults["test"].DeploymentResults), "should be equal")
 	assert.Equal(t, 1, len(actualAudit.NamespacedResults["test"].DeploymentResults), "should be equal")
 	assert.Equal(t, 1, len(actualAudit.NamespacedResults["test"].DeploymentResults[0].PodResult.ContainerResults), "should be equal")


### PR DESCRIPTION
Addresses https://github.com/reactiveops/polaris/issues/124

Uses whatever the user specifies as `--cluster-name`, falling back to the `host` named in kubeconfig. Doesn't look like we can get the `name` field: https://github.com/kubernetes/client-go/issues/530  

Any potential issues with surfacing the `host` in the dashboard? E.g. could it have basic auth creds?

Here's what it looks like:

<img width="1177" alt="Screen Shot 2019-06-05 at 4 53 43 PM" src="https://user-images.githubusercontent.com/7611973/58989757-85c94780-87b2-11e9-8b8c-74ebf44f7c4a.png">
