### PR TITLE
add instructions for local development 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Issues, whether bugs, tasks, or feature requests are essential for keeping Polar
 This project adheres to a [code of conduct](CODE_OF_CONDUCT.md). Please review this document before contributing to this project.
 
 ## Sign the CLA
-Before you can contribute, you will need to sign the [Contributor License Agreement]().
+Before you can contribute, you will need to sign the [Contributor License Agreement](https://cla-assistant.io/reactiveops/polaris).
 
 ## Project Structure
 
@@ -24,7 +24,7 @@ We label issues with the ["good first issue" tag](https://github.com/reactiveops
 
 ### Installation
 * Install the project with `go get github.com/reactiveops/polaris`
-* Change into the polaris directory which is installed at `~/go/src/github.com/reactiveops/polaris`
+* Change into the polaris directory which is installed at `$GOPATH/src/github.com/reactiveops/polaris`
 * See the dashboard with `go run main.go --dashboard`, then open http://localhost:8080/
 * See the audit data  `go run main.go --audit`. This command shows the audit information on the command line. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,13 @@
 # Contributing
 
-Issues, whether bugs, tasks, or feature requests are essential for keeping Polaris great. We believe it should be as easy as possible to contribute changes that get things working in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
+Issues, whether bugs, tasks, or feature requests are essential for keeping Polaris great. We believe it should be as easy as possible to contribute changes that get things working in your environment. There are a few guidelines that we need contributors to follow so that we can keep on top of things.
 
 ## Code of Conduct
 
 This project adheres to a [code of conduct](CODE_OF_CONDUCT.md). Please review this document before contributing to this project.
+
+## Sign the CLA
+Before you can contribute, you will need to sign the [Contributor License Agreement]().
 
 ## Project Structure
 
@@ -13,6 +16,19 @@ Polaris is built on top of [controller-runtime](https://github.com/kubernetes-si
 ## Getting Started
 
 We label issues with the ["good first issue" tag](https://github.com/reactiveops/polaris/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) if we believe they'll be a good starting point for new contributors. If you're interested in working on an issue, please start a conversation on that issue, and we can help answer any questions as they come up.
+
+
+## Setting Up Your Development Environment
+### Prerequisites
+* A properly configured Golang environment with Go 1.11 or higher
+* If you want to see the local changes you make on a Polaris dashboard, you will need access to a Kubernetes cluster defined in `~/.kube/config`
+
+### Installation
+* Install the project with `go get github.com/reactiveops/polaris`
+* Change into the polaris directory which is installed at `~/go/src/github.com/reactiveops/polaris`
+* See the dashboard with `go run main.go --dashboard`, then open http://localhost:8080/
+* See the audit data  `go run main.go --audit`. This command shows the audit information on the command line. 
+
 
 ## Running Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,6 @@ Polaris is built on top of [controller-runtime](https://github.com/kubernetes-si
 
 We label issues with the ["good first issue" tag](https://github.com/reactiveops/polaris/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) if we believe they'll be a good starting point for new contributors. If you're interested in working on an issue, please start a conversation on that issue, and we can help answer any questions as they come up.
 
-
 ## Setting Up Your Development Environment
 ### Prerequisites
 * A properly configured Golang environment with Go 1.11 or higher
@@ -28,7 +27,6 @@ We label issues with the ["good first issue" tag](https://github.com/reactiveops
 * Change into the polaris directory which is installed at `~/go/src/github.com/reactiveops/polaris`
 * See the dashboard with `go run main.go --dashboard`, then open http://localhost:8080/
 * See the audit data  `go run main.go --audit`. This command shows the audit information on the command line. 
-
 
 ## Running Tests
 


### PR DESCRIPTION
**What this PR does and why we need it** 

This PR adds instructions for how to run Polaris locally so people can setup the project on their computer. This will lower the barrier to entry for contributors that are outside of ReactiveOps. 

**Please note** 
I had to sign a CLA in order to work on the project, but I cannot find a link for it, so the 'Contributor License Agreement' url is blank. Please let me know where I can find that info. 