### PR TITLE
adjust os exit

### DIFF
--- a/pkg/kube/resources.go
+++ b/pkg/kube/resources.go
@@ -126,7 +126,11 @@ func CreateResourceProviderFromPath(directory string) (*ResourceProvider, error)
 
 // CreateResourceProviderFromCluster creates a new ResourceProvider using live data from a cluster
 func CreateResourceProviderFromCluster() (*ResourceProvider, error) {
-	kubeConf := config.GetConfig()
+	kubeConf, configError := config.GetConfig()
+	if configError != nil {
+		logrus.Errorf("Error fetching KubeConfig %v", configError)
+		return nil, configError
+	}
 	api, err := kubernetes.NewForConfig(kubeConf)
 	if err != nil {
 		logrus.Errorf("Error creating Kubernetes client %v", err)

--- a/pkg/kube/resources.go
+++ b/pkg/kube/resources.go
@@ -126,7 +126,7 @@ func CreateResourceProviderFromPath(directory string) (*ResourceProvider, error)
 
 // CreateResourceProviderFromCluster creates a new ResourceProvider using live data from a cluster
 func CreateResourceProviderFromCluster() (*ResourceProvider, error) {
-	kubeConf := config.GetConfigOrDie()
+	kubeConf := config.GetConfig()
 	api, err := kubernetes.NewForConfig(kubeConf)
 	if err != nil {
 		logrus.Errorf("Error creating Kubernetes client %v", err)


### PR DESCRIPTION
Fixes issue [#141](https://github.com/reactiveops/polaris/issues/141)

**What this PR does and why we need it**

I updated the `CreateResourceProviderFromCluster` function to find the KubeConfig and return an error if there is an issue retrieving the data. I wasn't able to figure out how to return the empty `ResourceProvider`, so I returned `nil` instead. Let me know if the empty `ResourceProvider` is necessary and I'll figure that out. 

See line 132 for the specific line I'm referring to: https://github.com/reactiveops/polaris/compare/ks/adjust-os-exit?expand=1#diff-5524e4ddda8206adfe02f6a98ed7160eR132