### PR TITLE
Add exit code flag 

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	webhook := flag.Bool("webhook", false, "Runs the webhook webserver.")
 	audit := flag.Bool("audit", false, "Runs a one-time audit.")
 	auditPath := flag.String("audit-path", "", "If specified, audits one or more YAML files instead of a cluster")
-	setExitCode := flag.Bool("exit-code", false, "set an exit code of 2 when the audit contains error-level issues.")
+	setExitCode := flag.Bool("set-exit-code-on-error", false, "set an exit code of 2 when the audit contains error-level issues.")
 	dashboardPort := flag.Int("dashboard-port", 8080, "Port for the dashboard webserver")
 	dashboardBasePath := flag.String("dashboard-base-path", "/", "Path on which the dashboard is served")
 	webhookPort := flag.Int("webhook-port", 9876, "Port for the webhook webserver")
@@ -194,8 +194,8 @@ func runAudit(c conf.Configuration, auditPath string, setExitCode bool, outputFi
 	}
 
 	if setExitCode && auditData.ClusterSummary.Results.Totals.Errors > 0 {
-		logrus.Errorf("Error found. Exiting audit.")
-		os.Exit(2)
+		logrus.Infof("Error found. Exiting audit.")
+		os.Exit(3)
 	}
 
 	var outputBytes []byte

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 	webhook := flag.Bool("webhook", false, "Runs the webhook webserver.")
 	audit := flag.Bool("audit", false, "Runs a one-time audit.")
 	auditPath := flag.String("audit-path", "", "If specified, audits one or more YAML files instead of a cluster")
+	exitCode := flag.String("exit-code", "", "set a non-zero exit code when the audit contains error-level issues.")
 	dashboardPort := flag.Int("dashboard-port", 8080, "Port for the dashboard webserver")
 	dashboardBasePath := flag.String("dashboard-base-path", "/", "Path on which the dashboard is served")
 	webhookPort := flag.Int("webhook-port", 9876, "Port for the webhook webserver")
@@ -180,6 +181,11 @@ func startWebhookServer(c conf.Configuration, disableWebhookConfigInstaller bool
 	}
 }
 
+func exitAudit() {
+	// if the audit contains error-level issues, exit with code 1
+	ox.Exit(1)
+}
+
 func runAudit(c conf.Configuration, auditPath string, outputFile string, outputURL string, outputFormat string) {
 	k, err := kube.CreateResourceProvider(auditPath)
 	if err != nil {
@@ -242,6 +248,7 @@ func runAudit(c conf.Configuration, auditPath string, outputFile string, outputU
 				os.Exit(1)
 			}
 
+			// exitAudit here? 
 			logrus.Infof("Received response: %v", body)
 		}
 

--- a/main.go
+++ b/main.go
@@ -193,11 +193,6 @@ func runAudit(c conf.Configuration, auditPath string, setExitCode bool, outputFi
 		panic(err)
 	}
 
-	if setExitCode && auditData.ClusterSummary.Results.Totals.Errors > 0 {
-		logrus.Infof("Error found. Exiting audit.")
-		os.Exit(3)
-	}
-
 	var outputBytes []byte
 	if outputFormat == "score" {
 		outputBytes = []byte(fmt.Sprint(auditData.ClusterSummary.Score))
@@ -258,5 +253,10 @@ func runAudit(c conf.Configuration, auditPath string, setExitCode bool, outputFi
 				os.Exit(1)
 			}
 		}
+	}
+
+	if setExitCode && auditData.ClusterSummary.Results.Totals.Errors > 0 {
+		logrus.Infof("Error found. Exiting audit.")
+		os.Exit(3)
 	}
 }


### PR DESCRIPTION
**What this PR does** 
This PR creates an `--set-exit-code-on-error` flag. If the user runs an audit and passes in this flag, the audit will exit with a status code of `3`. This functionality is most helpful for CI/CD use cases. 


**This PR addresses issue** [143](https://github.com/reactiveops/polaris/issues/143)